### PR TITLE
allow to unmatch pair to everyone

### DIFF
--- a/house_of_refuge/frontend/src/components/SubmissionRow.js
+++ b/house_of_refuge/frontend/src/components/SubmissionRow.js
@@ -39,9 +39,10 @@ const updateSub = (sub, fields, onCorrect = null) => {
 
     if (data.status === "success") {
       if (onCorrect) {
-
         onCorrect();
       }
+    } else {
+      throw new Error(data.message);
     }
     // toast(`${data.message}`, {type: data.status});
   }).catch((error) => {
@@ -305,7 +306,7 @@ export function SubmissionRow({sub, activeHandler, user, isGroupCoordinator, isA
         </td>
         <td colSpan={2} className={"text-center"}>
           {localSub.matcher &&
-              <Button variant={"secondary"} size={"sm"} onClick={freeUpMatcher}>Zwolnij zgłoszenie</Button>}
+              <Button variant={"danger"} size={"sm"} onClick={freeUpMatcher}>Zwolnij zgłoszenie</Button>}
         </td>
         <td colSpan={2} className={"text-center"}>
           {localSub.coordinator &&

--- a/house_of_refuge/main/views.py
+++ b/house_of_refuge/main/views.py
@@ -246,12 +246,13 @@ def update_sub(request, sub_id):
                         {"data": None,
                          "message": _("Someone is already processing this request"),
                          "status": "error"}, status=400)
-                elif sub.resource:
-                    #  we never want to free up sub with host
-                    return JsonResponse(
-                        {"data": None,
-                         "message": _("This request already has a host"),
-                         "status": "error"}, status=400)
+                # comment this out, as we may want to cancel matched pair (e.g., if button was pressed accidentally)
+                # elif sub.resource:
+                #     #  we never want to free up sub with host
+                #     return JsonResponse(
+                #         {"data": None,
+                #          "message": _("This request already has a host"),
+                #          "status": "error"}, status=400)
                 else:
                     setattr(sub, field, value)
 

--- a/house_of_refuge/main/views.py
+++ b/house_of_refuge/main/views.py
@@ -246,13 +246,6 @@ def update_sub(request, sub_id):
                         {"data": None,
                          "message": _("Someone is already processing this request"),
                          "status": "error"}, status=400)
-                # comment this out, as we may want to cancel matched pair (e.g., if button was pressed accidentally)
-                # elif sub.resource:
-                #     #  we never want to free up sub with host
-                #     return JsonResponse(
-                #         {"data": None,
-                #          "message": _("This request already has a host"),
-                #          "status": "error"}, status=400)
                 else:
                     setattr(sub, field, value)
 


### PR DESCRIPTION
* allow to unmatch pair to everyone (previously it only worked if only same user matched this pair)
* show error message on update-submission request (otherwise, it masks server response)
* paint `Zwolnij zgłoszenie` red to make it look available 
