### PR TITLE
Remove the distinction between coordinator types in the UI

### DIFF
--- a/house_of_refuge/frontend/src/i18n/locales/en/backoffice.json
+++ b/house_of_refuge/frontend/src/i18n/locales/en/backoffice.json
@@ -1,6 +1,5 @@
 {
-  "terrain_coordinators": "Field coordinators",
-  "remote_coordinators": "Remote coordinators",
+  "coordinators": "Coordinators",
   "log_out": "Log out",
   "today_we_helped_count": "Today we helped {pplHelpedCount} people",
   "source": "Source",

--- a/house_of_refuge/frontend/src/i18n/locales/pl/backoffice.json
+++ b/house_of_refuge/frontend/src/i18n/locales/pl/backoffice.json
@@ -1,6 +1,5 @@
 {
-  "terrain_coordinators": "Koordynatorzy Zachodni",
-  "remote_coordinators": "Koordynatorzy Zdalni",
+  "coordinators": "Koordynatorzy",
   "log_out": "Wyloguj się",
   "today_we_helped_count": "Pomogliśmy dziś {pplHelpedCount} osobom",
   "source": "Źródło",

--- a/house_of_refuge/frontend/src/scripts/index.js
+++ b/house_of_refuge/frontend/src/scripts/index.js
@@ -22,6 +22,7 @@ import {BrowserRouter, Route, Routes, useSearchParams} from "react-router-dom";
 const CoordinatorsHeader = ({coordinators, helped, hide}) => {
   const [peopleHelped, setPeopleHelped] = useState(helped);
   const [collapsed, setCollapsed] = useState(false);
+  const all_coordinators = (coordinators.station || []).concat(coordinators.remote || [])
 
   useInterval(async () => {
     const newHelped = await getHelped();
@@ -35,12 +36,8 @@ const CoordinatorsHeader = ({coordinators, helped, hide}) => {
     <div className="coordinators" style={{ display: collapsed ? 'none' : 'block' }}>
       <div className="d-flex justify-content-around">
         <div className={"mx-5 text-center"}>
-          <h5>Koordynatorzy Zachodni</h5>
-          <ol>{(coordinators.station || []).map(c => <li key={c.user.id}>{c.user.display}</li>)}</ol>
-        </div>
-        <div className={"mx-5 text-center"}>
-          <h5>Koordynatorzy Zdalni</h5>
-          <ol>{(coordinators.remote || []).map(c => <li key={c.user.id}>{c.user.display}</li>)}</ol>
+          <h5>Koordynatorzy</h5>
+            <ol>{all_coordinators.map(c => <li key={c.user.id}>{c.user.display}</li>)}</ol>
         </div>
       </div>
       {peopleHelped ?


### PR DESCRIPTION
Tested with a basic scenario of having two coordinators of distinct types.

Admin panel still requires specifying the type of a new coordinator, and all the underlying layers still process this field - the distinction has been removed only on the UI level.